### PR TITLE
Sprint2

### DIFF
--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -15,26 +15,29 @@
 namespace opossum {
 
 void Chunk::add_segment(std::shared_ptr<BaseSegment> segment) {
-  // Implementation goes here
+  if (size() != 0 && segment->size() != size()) {
+    throw std::runtime_error("Segment needs to have same number of rows as Chunk.");
+  }
+
+  _segments.push_back(segment);
 }
 
 void Chunk::append(const std::vector<AllTypeVariant>& values) {
-  // Implementation goes here
+  DebugAssert(values.size() == column_count(), "Needs same number of values as columns.");
+  for (auto i = 0ul, end = values.size(); i < end; i++) {
+    _segments[i]->append(values[i]);
+  }
 }
 
-std::shared_ptr<BaseSegment> Chunk::get_segment(ColumnID column_id) const {
-  // Implementation goes here
-  return nullptr;
-}
+std::shared_ptr<BaseSegment> Chunk::get_segment(ColumnID column_id) const { return _segments.at(column_id); }
 
-ColumnCount Chunk::column_count() const {
-  // Implementation goes here
-  return ColumnCount{0};
-}
+ColumnCount Chunk::column_count() const { return ColumnCount{_segments.size()}; }
 
 ChunkOffset Chunk::size() const {
-  // Implementation goes here
-  return 0;
+  if (_segments.empty()) {
+    return 0;
+  }
+  return _segments[0]->size();
 }
 
 }  // namespace opossum

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -28,7 +28,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
 
 std::shared_ptr<BaseSegment> Chunk::get_segment(ColumnID column_id) const { return _segments.at(column_id); }
 
-ColumnCount Chunk::column_count() const { return ColumnCount{_segments.size()}; }
+ColumnCount Chunk::column_count() const { return static_cast<ColumnCount>(_segments.size()); }
 
 ChunkOffset Chunk::size() const {
   if (_segments.empty()) {

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -15,9 +15,7 @@
 namespace opossum {
 
 void Chunk::add_segment(std::shared_ptr<BaseSegment> segment) {
-  if (size() != 0 && segment->size() != size()) {
-    throw std::runtime_error("Segment needs to have same number of rows as chunk");
-  }
+  Assert(size() == 0 || segment->size() == size(), "Segment needs to have same number of rows as chunk");
   _segments.push_back(segment);
 }
 

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -16,14 +16,13 @@ namespace opossum {
 
 void Chunk::add_segment(std::shared_ptr<BaseSegment> segment) {
   if (size() != 0 && segment->size() != size()) {
-    throw std::runtime_error("Segment needs to have same number of rows as Chunk.");
+    throw std::runtime_error("Segment needs to have same number of rows as chunk");
   }
-
   _segments.push_back(segment);
 }
 
 void Chunk::append(const std::vector<AllTypeVariant>& values) {
-  DebugAssert(values.size() == column_count(), "Needs same number of values as columns.");
+  DebugAssert(values.size() == column_count(), "New values need same number of values as chunk columns");
   for (auto i = 0ul, end = values.size(); i < end; i++) {
     _segments[i]->append(values[i]);
   }

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -41,7 +41,7 @@ class Chunk : private Noncopyable {
   std::shared_ptr<BaseSegment> get_segment(ColumnID column_id) const;
 
  protected:
-  // Implementation goes here
+  std::vector<std::shared_ptr<BaseSegment>> _segments;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/dictionary_segment.hpp
+++ b/src/lib/storage/dictionary_segment.hpp
@@ -8,9 +8,9 @@
 #include <vector>
 
 #include "all_type_variant.hpp"
+#include "fixed_size_attribute_vector.hpp"
 #include "type_cast.hpp"
 #include "types.hpp"
-#include "fixed_size_attribute_vector.hpp"
 
 namespace opossum {
 
@@ -43,13 +43,12 @@ class DictionarySegment : public BaseSegment {
 
     auto dictionary_size = _dictionary->size();
 
-    auto required_bit_size = std::ceil(std::log(dictionary_size)/std::log(2));
-
+    auto required_bit_size = std::ceil(std::log(dictionary_size) / std::log(2));
 
     // Werte < 8 etc. versuchen durch 2^ceil(log(required_bit_size)) auf 8, 16, 32 zu bringen
-    if (required_bit_size <= 8){
+    if (required_bit_size <= 8) {
       _attribute_vector = std::make_shared<FixedSizeAttributeVector<uint8_t>>(segment_size);
-    } else if (required_bit_size <= 16){
+    } else if (required_bit_size <= 16) {
       _attribute_vector = std::make_shared<FixedSizeAttributeVector<uint16_t>>(segment_size);
     } else {
       _attribute_vector = std::make_shared<FixedSizeAttributeVector<uint32_t>>(segment_size);

--- a/src/lib/storage/dictionary_segment.hpp
+++ b/src/lib/storage/dictionary_segment.hpp
@@ -65,7 +65,7 @@ class DictionarySegment : public BaseSegment {
   std::shared_ptr<const std::vector<T>> dictionary() const { return _dictionary; }
 
   // returns the attribute vector
-  std::shared_ptr<const BaseAttributeVector> attribute_vector() const { return _attribute_vector; }
+  //std::shared_ptr<const BaseAttributeVector> attribute_vector() const { return _attribute_vector; }
 
   // return the value represented by a given ValueID
   const T& value_by_value_id(ValueID value_id) { return _dictionary->at(value_id); }
@@ -77,7 +77,7 @@ class DictionarySegment : public BaseSegment {
     if (lower_bound_it == _dictionary->end()) {
       return INVALID_VALUE_ID;
     }
-    return ValueID{std::distance(_dictionary->begin(), lower_bound_it)};
+    return static_cast<ValueID>(std::distance(_dictionary->begin(), lower_bound_it));
   }
 
   // same as lower_bound(T), but accepts an AllTypeVariant
@@ -93,7 +93,7 @@ class DictionarySegment : public BaseSegment {
     if (upper_bound_it == _dictionary->end()) {
       return INVALID_VALUE_ID;
     }
-    return ValueID{std::distance(_dictionary->begin(), upper_bound_it)};
+    return static_cast<ValueID>(std::distance(_dictionary->begin(), upper_bound_it));
   }
 
   // same as upper_bound(T), but accepts an AllTypeVariant

--- a/src/lib/storage/dictionary_segment.hpp
+++ b/src/lib/storage/dictionary_segment.hpp
@@ -25,55 +25,73 @@ class DictionarySegment : public BaseSegment {
   /**
    * Creates a Dictionary segment from a given value segment.
    */
-  explicit DictionarySegment(const std::shared_ptr<BaseSegment>& base_segment);
-
-  // SEMINAR INFORMATION: Since most of these methods depend on the template parameter, you will have to implement
-  // the DictionarySegment in this file. Replace the method signatures with actual implementations.
+  explicit DictionarySegment(const std::shared_ptr<BaseSegment>& base_segment) {}
 
   // return the value at a certain position. If you want to write efficient operators, back off!
-  AllTypeVariant operator[](const ChunkOffset chunk_offset) const override;
+  AllTypeVariant operator[](const ChunkOffset chunk_offset) const override {
+    const auto dictionary_value = _dictionary->at(_attribute_vector->at(chunk_offset));
+    return static_cast<AllTypeVariant>(dictionary_value);
+  }
 
   // return the value at a certain position.
-  T get(const size_t chunk_offset) const;
+  T get(const size_t chunk_offset) const { return _dictionary->at(_attribute_vector->at(chunk_offset)); }
 
   // dictionary segments are immutable
-  void append(const AllTypeVariant& val) override;
+  void append(const AllTypeVariant& val) override { throw std::runtime_error("Cannot append to immutable segments"); }
 
-  // returns an underlying dictionary
-  std::shared_ptr<const std::vector<T>> dictionary() const;
+  // returns the underlying dictionary
+  std::shared_ptr<const std::vector<T>> dictionary() const { return _dictionary; }
 
-  // returns an underlying data structure
-  std::shared_ptr<const BaseAttributeVector> attribute_vector() const;
+  // returns the attribute vector
+  std::shared_ptr<const BaseAttributeVector> attribute_vector() const { return _attribute_vector; }
 
   // return the value represented by a given ValueID
-  const T& value_by_value_id(ValueID value_id) const;
+  const T& value_by_value_id(ValueID value_id) { return _dictionary->at(value_id); }
 
   // returns the first value ID that refers to a value >= the search value
   // returns INVALID_VALUE_ID if all values are smaller than the search value
-  ValueID lower_bound(T value) const;
+  ValueID lower_bound(T value) const {
+    const auto lower_bound_it = std::lower_bound(_dictionary->begin(), _dictionary->end(), value);
+    if (lower_bound_it == _dictionary->end()) {
+      return INVALID_VALUE_ID;
+    }
+    return ValueID{std::distance(_dictionary->begin(), lower_bound_it)};
+  }
 
   // same as lower_bound(T), but accepts an AllTypeVariant
-  ValueID lower_bound(const AllTypeVariant& value) const;
+  ValueID lower_bound(const AllTypeVariant& value) const {
+    const T typed_value = static_cast<T>(value);
+    return lower_bound(typed_value);
+  }
 
   // returns the first value ID that refers to a value > the search value
   // returns INVALID_VALUE_ID if all values are smaller than or equal to the search value
-  ValueID upper_bound(T value) const;
+  ValueID upper_bound(T value) const {
+    const auto upper_bound_it = std::upper_bound(_dictionary->begin(), _dictionary->end(), value);
+    if (upper_bound_it == _dictionary->end()) {
+      return INVALID_VALUE_ID;
+    }
+    return ValueID{std::distance(_dictionary->begin(), upper_bound_it)};
+  }
 
   // same as upper_bound(T), but accepts an AllTypeVariant
-  ValueID upper_bound(const AllTypeVariant& value) const;
+  ValueID upper_bound(const AllTypeVariant& value) const {
+    const T typed_value = static_cast<T>(value);
+    return upper_bound(typed_value);
+  }
 
   // return the number of unique_values (dictionary entries)
-  size_t unique_values_count() const;
+  size_t unique_values_count() const { return _dictionary->size(); }
 
   // return the number of entries
-  ChunkOffset size() const override;
+  ChunkOffset size() const override { return static_cast<ChunkOffset>(_attribute_vector->size()); }
 
   // returns the calculated memory usage
   size_t estimate_memory_usage() const final;
 
  protected:
   std::shared_ptr<std::vector<T>> _dictionary;
-  std::shared_ptr<BaseAttributeVector> _attribute_vector;
+  std::shared_ptr<std::vector<uint32_t>> _attribute_vector;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/dictionary_segment.hpp
+++ b/src/lib/storage/dictionary_segment.hpp
@@ -45,7 +45,8 @@ class DictionarySegment : public BaseSegment {
 
     auto required_bit_size = std::ceil(std::log(dictionary_size)/std::log(2));
 
-    // Werte < 8 etc. versuchen durch 2^ceil(log(required_bit_size)) auf 8, 16, 32
+
+    // Werte < 8 etc. versuchen durch 2^ceil(log(required_bit_size)) auf 8, 16, 32 zu bringen
     if (required_bit_size <= 8){
       _attribute_vector = std::make_shared<FixedSizeAttributeVector<uint8_t>>(segment_size);
     } else if (required_bit_size <= 16){
@@ -122,7 +123,9 @@ class DictionarySegment : public BaseSegment {
   ChunkOffset size() const override { return static_cast<ChunkOffset>(_attribute_vector->size()); }
 
   // returns the calculated memory usage
-  size_t estimate_memory_usage() const final { return 0; }
+  size_t estimate_memory_usage() const final {
+    return (sizeof(T) * _dictionary->size() + _attribute_vector->width() * _attribute_vector->size());
+  }
 
  protected:
   std::shared_ptr<std::vector<T>> _dictionary;

--- a/src/lib/storage/fixed_size_attribute_vector.hpp
+++ b/src/lib/storage/fixed_size_attribute_vector.hpp
@@ -2,19 +2,18 @@
 
 #include <vector>
 
-#include "utils/assert.hpp"
 #include "base_attribute_vector.hpp"
 #include "type_cast.hpp"
+#include "utils/assert.hpp"
 
 namespace opossum {
 
 template <typename T>
 class FixedSizeAttributeVector : public BaseAttributeVector {
  public:
-  FixedSizeAttributeVector(size_t attribute_vector_size){
+  explicit FixedSizeAttributeVector(size_t attribute_vector_size) {
     _attributes = std::vector<T>(attribute_vector_size);
   }
-  //FixedSizeAttributeVector() = default;
   virtual ~FixedSizeAttributeVector() = default;
 
   // we need to explicitly set the move constructor to default when
@@ -23,27 +22,21 @@ class FixedSizeAttributeVector : public BaseAttributeVector {
   FixedSizeAttributeVector& operator=(FixedSizeAttributeVector&&) = default;
 
   // returns the value id at a given position
-  ValueID get(const size_t position) const { 
-    return static_cast<ValueID>(_attributes.at(position)); 
-  }
+  ValueID get(const size_t position) const { return static_cast<ValueID>(_attributes.at(position)); }
 
   // sets the value id at a given position
   void set(const size_t position, const ValueID value_id) {
-    DebugAssert(position >=0 && position < _attributes.size(), "Not a valid position");
+    DebugAssert(position >= 0 && position < _attributes.size(), "Not a valid position");
     _attributes[position] = static_cast<T>(value_id);
-  };
+  }
 
   // returns the number of values
-  size_t size() const {
-    return _attributes.size();
-  }
+  size_t size() const { return _attributes.size(); }
 
   // returns the width of biggest value id in bytes
-  AttributeVectorWidth width() const {
-    return static_cast<AttributeVectorWidth>(sizeof(T));
-  }
+  AttributeVectorWidth width() const { return static_cast<AttributeVectorWidth>(sizeof(T)); }
 
-  private: 
-  std::vector<T> _attributes = {}; 
+ private:
+  std::vector<T> _attributes = {};
 };
 }  // namespace opossum

--- a/src/lib/storage/fixed_size_attribute_vector.hpp
+++ b/src/lib/storage/fixed_size_attribute_vector.hpp
@@ -11,8 +11,10 @@ namespace opossum {
 template <typename T>
 class FixedSizeAttributeVector : public BaseAttributeVector {
  public:
-  //FixedSizeAttributeVector(size_t attribute_vector_size) : _attributes(attribute_vector_size){};
-  FixedSizeAttributeVector() = default;
+  FixedSizeAttributeVector(size_t attribute_vector_size){
+    _attributes = std::vector<T>(attribute_vector_size);
+  }
+  //FixedSizeAttributeVector() = default;
   virtual ~FixedSizeAttributeVector() = default;
 
   // we need to explicitly set the move constructor to default when

--- a/src/lib/storage/fixed_size_attribute_vector.hpp
+++ b/src/lib/storage/fixed_size_attribute_vector.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <vector>
+
+#include "utils/assert.hpp"
+#include "base_attribute_vector.hpp"
+#include "type_cast.hpp"
+
+namespace opossum {
+
+template <typename T>
+class FixedSizeAttributeVector : public BaseAttributeVector {
+ public:
+  //FixedSizeAttributeVector(size_t attribute_vector_size) : _attributes(attribute_vector_size){};
+  FixedSizeAttributeVector() = default;
+  virtual ~FixedSizeAttributeVector() = default;
+
+  // we need to explicitly set the move constructor to default when
+  // we overwrite the copy constructor
+  FixedSizeAttributeVector(FixedSizeAttributeVector&&) = default;
+  FixedSizeAttributeVector& operator=(FixedSizeAttributeVector&&) = default;
+
+  // returns the value id at a given position
+  ValueID get(const size_t position) const { 
+    return static_cast<ValueID>(_attributes.at(position)); 
+  }
+
+  // sets the value id at a given position
+  void set(const size_t position, const ValueID value_id) {
+    DebugAssert(position >=0 && position < _attributes.size(), "Not a valid position");
+    _attributes[position] = static_cast<T>(value_id);
+  };
+
+  // returns the number of values
+  size_t size() const {
+    return _attributes.size();
+  }
+
+  // returns the width of biggest value id in bytes
+  AttributeVectorWidth width() const {
+    return static_cast<AttributeVectorWidth>(sizeof(T));
+  }
+
+  private: 
+  std::vector<T> _attributes = {}; 
+};
+}  // namespace opossum

--- a/src/lib/storage/fixed_size_attribute_vector.hpp
+++ b/src/lib/storage/fixed_size_attribute_vector.hpp
@@ -26,7 +26,7 @@ class FixedSizeAttributeVector : public BaseAttributeVector {
 
   // sets the value id at a given position
   void set(const size_t position, const ValueID value_id) {
-    DebugAssert(position >= 0 && position < _attributes.size(), "Not a valid position");
+    DebugAssert(position >= 0 && position < _attributes.size(), "Cannot set value at invalid position");
     _attributes[position] = static_cast<T>(value_id);
   }
 

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -1,5 +1,6 @@
 #include "storage_manager.hpp"
 
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -10,38 +11,38 @@
 namespace opossum {
 
 StorageManager& StorageManager::get() {
-  return *(new StorageManager());
-  // A really hacky fix to get the tests to run - replace this with your implementation
+  static StorageManager storageManager;
+  return storageManager;
 }
 
-void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) {
-  // Implementation goes here
-}
+void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) { _tables[name] = table; }
 
 void StorageManager::drop_table(const std::string& name) {
-  // Implementation goes here
+  if (!_tables[name]) {
+    throw std::runtime_error("Cannot drop non-existing table.");
+  }
+  _tables.erase(name);
 }
 
-std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const {
-  // Implementation goes here
-  return nullptr;
-}
+std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const { return _tables.at(name); }
 
-bool StorageManager::has_table(const std::string& name) const {
-  // Implementation goes here
-  return false;
-}
+bool StorageManager::has_table(const std::string& name) const { return _tables.contains(name); }
 
 std::vector<std::string> StorageManager::table_names() const {
-  throw std::runtime_error("Implement StorageManager::table_names");
+  auto table_names = std::vector<std::string>();
+  for (const auto& [table_name, table] : _tables) {
+    table_names.push_back(table_name);
+  }
+  return table_names;
 }
 
 void StorageManager::print(std::ostream& out) const {
-  // Implementation goes here
+  for (const auto& [table_name, table] : _tables) {
+    std::cout << table_name << " #columns: " << table->column_count() << " #rows: " << table->row_count()
+              << " #chunks: " << table->chunk_count() << std::endl;
+  }
 }
 
-void StorageManager::reset() {
-  // Implementation goes here;
-}
+void StorageManager::reset() { get() = StorageManager{}; }
 
 }  // namespace opossum

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -16,16 +16,12 @@ StorageManager& StorageManager::get() {
 }
 
 void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) {
-  if (has_table(name)) {
-    throw std::runtime_error("Cannot add table, because a table with this name already exists");
-  }
+  Assert(!has_table(name), "Cannot add table, because a table with this name already exists");
   _tables[name] = table;
 }
 
 void StorageManager::drop_table(const std::string& name) {
-  if (!_tables[name]) {
-    throw std::runtime_error("Cannot drop non-existing table");
-  }
+  Assert(has_table(name), "Cannot drop non-existing table");
   _tables.erase(name);
 }
 

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -15,7 +15,12 @@ StorageManager& StorageManager::get() {
   return storageManager;
 }
 
-void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) { _tables[name] = table; }
+void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) { 
+  if (has_table(name)) {
+    throw std::runtime_error("Cannot add table, because a table with this name already exists");
+  }
+  _tables[name] = table; 
+}
 
 void StorageManager::drop_table(const std::string& name) {
   if (!_tables[name]) {
@@ -24,7 +29,9 @@ void StorageManager::drop_table(const std::string& name) {
   _tables.erase(name);
 }
 
-std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const { return _tables.at(name); }
+std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const { 
+  return _tables.at(name); 
+}
 
 bool StorageManager::has_table(const std::string& name) const { return _tables.contains(name); }
 

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -24,7 +24,7 @@ void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> t
 
 void StorageManager::drop_table(const std::string& name) {
   if (!_tables[name]) {
-    throw std::runtime_error("Cannot drop non-existing table.");
+    throw std::runtime_error("Cannot drop non-existing table");
   }
   _tables.erase(name);
 }
@@ -42,6 +42,7 @@ std::vector<std::string> StorageManager::table_names() const {
 }
 
 void StorageManager::print(std::ostream& out) const {
+  std::cout << "StorageManager #tables: " << _tables.size() << std::endl;
   for (const auto& [table_name, table] : _tables) {
     std::cout << table_name << " #columns: " << table->column_count() << " #rows: " << table->row_count()
               << " #chunks: " << table->chunk_count() << std::endl;

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -1,6 +1,5 @@
 #include "storage_manager.hpp"
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -30,7 +29,8 @@ std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const 
 bool StorageManager::has_table(const std::string& name) const { return _tables.contains(name); }
 
 std::vector<std::string> StorageManager::table_names() const {
-  auto table_names = std::vector<std::string>();
+  std::vector<std::string> table_names;
+  table_names.reserve(_tables.size());
   for (const auto& [table_name, table] : _tables) {
     table_names.push_back(table_name);
   }

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -15,11 +15,11 @@ StorageManager& StorageManager::get() {
   return storageManager;
 }
 
-void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) { 
+void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) {
   if (has_table(name)) {
     throw std::runtime_error("Cannot add table, because a table with this name already exists");
   }
-  _tables[name] = table; 
+  _tables[name] = table;
 }
 
 void StorageManager::drop_table(const std::string& name) {
@@ -29,9 +29,7 @@ void StorageManager::drop_table(const std::string& name) {
   _tables.erase(name);
 }
 
-std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const { 
-  return _tables.at(name); 
-}
+std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const { return _tables.at(name); }
 
 bool StorageManager::has_table(const std::string& name) const { return _tables.contains(name); }
 

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "storage/table.hpp"
@@ -44,6 +45,6 @@ class StorageManager : private Noncopyable {
   StorageManager() {}
   StorageManager& operator=(StorageManager&&) = default;
 
-  // Implementation goes here
+  std::unordered_map<std::string, std::shared_ptr<Table>> _tables;
 };
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -97,7 +98,7 @@ void Table::compress_chunk(ChunkID chunk_id) {
   const auto chunk_column_count = chunk.column_count();
   for (auto column = 0; column < chunk_column_count; column++) {
     const auto segment_type = _column_types[column];
-    _add_dictionary_segment_to_chunk(compressed_chunk, segment_type, chunk.get_segment(static_cast<ColumnID>(column)));
+    std::thread thread(_add_dictionary_segment_to_chunk,compressed_chunk, segment_type, chunk.get_segment(static_cast<ColumnID>(column));
   }
   _chunks[chunk_id] = compressed_chunk;
 }

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -48,7 +48,7 @@ ColumnCount Table::column_count() const { return _chunks[0]->column_count(); }
 
 uint64_t Table::row_count() const {
   uint64_t row_count = 0;
-  for (const auto &chunk : _chunks) {
+  for (const auto& chunk : _chunks) {
     row_count = row_count + chunk->size();
   }
   return row_count;
@@ -100,12 +100,13 @@ void Table::compress_chunk(ChunkID chunk_id) {
   std::vector<std::thread> threads;
 
   for (auto column = 0; column < chunk_column_count; column++) {
-     const auto segment_type = _column_types[column];
-     auto segment = chunk.get_segment(static_cast<ColumnID>(column));
+    const auto segment_type = _column_types[column];
+    auto segment = chunk.get_segment(static_cast<ColumnID>(column));
 
-    threads.emplace_back(std::thread(&Table::_add_dictionary_segment_to_chunk, this, std::ref(compressed_chunk), segment_type, segment));
+    threads.emplace_back(
+        std::thread(&Table::_add_dictionary_segment_to_chunk, this, std::ref(compressed_chunk), segment_type, segment));
   }
-  for (size_t index = 0; index < threads.size(); index++) {
+  for (auto index = 0ul, number_threads = threads.size(); index < number_threads; index++) {
     threads[index].join();
   }
   _chunks[chunk_id] = compressed_chunk;

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -99,6 +99,7 @@ void Table::compress_chunk(ChunkID chunk_id) {
     const auto segment_type = _column_types[column];
     _add_dictionary_segment_to_chunk(compressed_chunk, segment_type, chunk.get_segment(static_cast<ColumnID>(column)));
   }
+  _chunks[chunk_id] = compressed_chunk;
 }
 
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -23,9 +23,8 @@ Table::Table(const ChunkOffset target_chunk_size) {
 }
 
 void Table::add_column(const std::string& name, const std::string& type) {
-  if (row_count() != 0) {
-    throw std::runtime_error("Cannot add column to non-empty table");
-  }
+  Assert(row_count() == 0, "Cannot add column to non-empty table");
+
   _column_names.push_back(name);
   _column_types.push_back(type);
   _add_value_segment_to_chunk(_chunks[0], type);
@@ -55,9 +54,8 @@ ChunkID Table::chunk_count() const { return ChunkID{_chunks.size()}; }
 
 ColumnID Table::column_id_by_name(const std::string& column_name) const {
   const auto it = std::find(_column_names.begin(), _column_names.end(), column_name);
-  if (it == _column_names.end()) {
-    throw std::runtime_error("Column not found");
-  }
+  Assert(it != _column_names.end(), "Column not found");
+  
   return static_cast<ColumnID>(std::distance(_column_names.begin(), it));
 }
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -55,7 +55,7 @@ ChunkID Table::chunk_count() const { return ChunkID{_chunks.size()}; }
 ColumnID Table::column_id_by_name(const std::string& column_name) const {
   const auto it = std::find(_column_names.begin(), _column_names.end(), column_name);
   Assert(it != _column_names.end(), "Column not found");
-  
+
   return static_cast<ColumnID>(std::distance(_column_names.begin(), it));
 }
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -24,7 +24,7 @@ Table::Table(const ChunkOffset target_chunk_size) {
 
 void Table::add_column(const std::string& name, const std::string& type) {
   if (row_count() != 0) {
-    throw std::runtime_error("Cannot add column to non empty table.");
+    throw std::runtime_error("Cannot add column to non-empty table");
   }
   _column_names.push_back(name);
   _column_types.push_back(type);
@@ -46,17 +46,17 @@ void Table::append(const std::vector<AllTypeVariant>& values) {
 ColumnCount Table::column_count() const { return _chunks[0]->column_count(); }
 
 uint64_t Table::row_count() const {
-  auto completed_chunks_size = (chunk_count() - 1) * _target_chunk_size;
-  auto last_chunk_size = _chunks[chunk_count() - 1]->size();
+  const auto completed_chunks_size = (chunk_count() - 1) * _target_chunk_size;
+  const auto last_chunk_size = _chunks[chunk_count() - 1]->size();
   return completed_chunks_size + last_chunk_size;
 }
 
 ChunkID Table::chunk_count() const { return ChunkID{_chunks.size()}; }
 
 ColumnID Table::column_id_by_name(const std::string& column_name) const {
-  auto it = std::find(_column_names.begin(), _column_names.end(), column_name);
+  const auto it = std::find(_column_names.begin(), _column_names.end(), column_name);
   if (it == _column_names.end()) {
-    throw std::runtime_error("Column not found.");
+    throw std::runtime_error("Column not found");
   }
   return static_cast<ColumnID>(std::distance(_column_names.begin(), it));
 }

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -95,6 +95,7 @@ void Table::_add_dictionary_segment_to_chunk(std::shared_ptr<Chunk>& chunk, cons
   resolve_data_type(type, [&](const auto data_type_t) {
     using ColumnDataType = typename decltype(data_type_t)::type;
     const auto dictionary_segment = std::make_shared<DictionarySegment<ColumnDataType>>(value_segment);
+    std::lock_guard<std::mutex> guard(_add_segment_lock);
     chunk->add_segment(dictionary_segment);
   });
 }

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -96,9 +96,17 @@ void Table::compress_chunk(ChunkID chunk_id) {
   auto compressed_chunk = std::make_shared<Chunk>();
   const auto& chunk = get_chunk(chunk_id);
   const auto chunk_column_count = chunk.column_count();
+
+  std::vector<std::thread> threads;
+
   for (auto column = 0; column < chunk_column_count; column++) {
-    const auto segment_type = _column_types[column];
-    std::thread thread(_add_dictionary_segment_to_chunk,compressed_chunk, segment_type, chunk.get_segment(static_cast<ColumnID>(column));
+     const auto segment_type = _column_types[column];
+     auto segment = chunk.get_segment(static_cast<ColumnID>(column));
+
+    threads.emplace_back(std::thread(&Table::_add_dictionary_segment_to_chunk, this, std::ref(compressed_chunk), segment_type, segment));
+  }
+  for (size_t index = 0; index < threads.size(); index++) {
+    threads[index].join();
   }
   _chunks[chunk_id] = compressed_chunk;
 }

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -98,13 +98,11 @@ void Table::_add_value_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std
   });
 }
 
-void Table::_add_dictionary_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type,
-                                             const std::shared_ptr<BaseSegment>& value_segment) {
+void Table::_add_dictionary_segment_to_vector(std::vector<std::shared_ptr<BaseSegment>>& compressed_segments, const std::string& type,
+                                             const std::shared_ptr<BaseSegment>& segment, const ColumnID column_id) {
   resolve_data_type(type, [&](const auto data_type_t) {
     using ColumnDataType = typename decltype(data_type_t)::type;
-    const auto dictionary_segment = std::make_shared<DictionarySegment<ColumnDataType>>(value_segment);
-    std::lock_guard<std::mutex> guard(_add_segment_lock);
-    chunk->add_segment(dictionary_segment);
+    compressed_segments[column_id] = std::make_shared<DictionarySegment<ColumnDataType>>(segment);
   });
 }
 
@@ -114,19 +112,29 @@ void Table::compress_chunk(ChunkID chunk_id) {
   const auto chunk_column_count = chunk.column_count();
 
   std::vector<std::thread> threads;
+  threads.reserve(chunk_column_count);
 
-  for (auto column = 0; column < chunk_column_count; column++) {
-    const auto segment_type = _column_types[column];
-    auto segment = chunk.get_segment(static_cast<ColumnID>(column));
-
-    threads.emplace_back(
-        std::thread(&Table::_add_dictionary_segment_to_chunk, this, std::ref(compressed_chunk), segment_type, segment));
+  auto compressed_segments = std::vector<std::shared_ptr<BaseSegment>>{chunk_column_count};
+ 
+  // Compress each segment in chunk by creating dictionary segments concurrently
+  for (auto column_id = ColumnID{0}; column_id < chunk_column_count; ++column_id) {
+    const auto segment_type = _column_types[column_id];
+    auto segment = chunk.get_segment(column_id);
+    
+    threads.emplace_back(&Table::_add_dictionary_segment_to_vector, this, std::ref(compressed_segments), segment_type, segment, column_id);
   }
 
+  // Wait for all compressions to be finished
   for (auto& thread : threads) {
     thread.join();
   }
 
+  // Add compressed segments to chunk
+  for (auto column_id = ColumnID{0}; column_id < chunk_column_count; ++column_id) {
+    compressed_chunk->add_segment(compressed_segments[column_id]);
+  }
+
+  // Swap uncompressed with compressed chunk
   _chunks[chunk_id] = compressed_chunk;
 }
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -54,11 +54,6 @@ void Table::create_new_chunk() {
   // Implementation goes here
 }
 
-ColumnCount Table::column_count() const {
-  // Implementation goes here
-  return ColumnCount{0};
-}
-
 uint64_t Table::row_count() const {
   return std::accumulate(_chunks.cbegin(), _chunks.cend(), 0,
                          [](uint64_t accumulated_size, const auto& chunk) { return accumulated_size + chunk->size(); });

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -18,56 +18,67 @@
 namespace opossum {
 
 Table::Table(const ChunkOffset target_chunk_size) {
-  // Implementation goes here
+  _target_chunk_size = target_chunk_size;
+  _chunks.push_back(std::make_shared<Chunk>());
 }
 
 void Table::add_column(const std::string& name, const std::string& type) {
-  // Implementation goes here
+  if (row_count() != 0) {
+    throw std::runtime_error("Cannot add column to non empty table.");
+  }
+  _column_names.push_back(name);
+  _column_types.push_back(type);
+  _add_value_segment_to_chunk(_chunks[0], type);
 }
 
 void Table::append(const std::vector<AllTypeVariant>& values) {
-  // Implementation goes here
+  auto last_chunk = _chunks[chunk_count() - 1];
+  if (last_chunk->size() == _target_chunk_size) {
+    last_chunk = std::make_shared<Chunk>();
+    for (auto column_type : _column_types) {
+      _add_value_segment_to_chunk(last_chunk, column_type);
+    }
+    _chunks.push_back(last_chunk);
+  }
+  last_chunk->append(values);
 }
 
-ColumnCount Table::column_count() const {
-  // Implementation goes here
-  return ColumnCount{0};
-}
+ColumnCount Table::column_count() const { return _chunks[0]->column_count(); }
 
 uint64_t Table::row_count() const {
-  // Implementation goes here
-  return 0;
+  auto completed_chunks_size = (chunk_count() - 1) * _target_chunk_size;
+  auto last_chunk_size = _chunks[chunk_count() - 1]->size();
+  return completed_chunks_size + last_chunk_size;
 }
 
-ChunkID Table::chunk_count() const {
-  // Implementation goes here
-  return ChunkID{0};
-}
+ChunkID Table::chunk_count() const { return ChunkID{_chunks.size()}; }
 
 ColumnID Table::column_id_by_name(const std::string& column_name) const {
-  // Implementation goes here
-  return ColumnID{0};
+  auto it = std::find(_column_names.begin(), _column_names.end(), column_name);
+  if (it == _column_names.end()) {
+    throw std::runtime_error("Column not found.");
+  }
+  return static_cast<ColumnID>(std::distance(_column_names.begin(), it));
 }
 
-ChunkOffset Table::target_chunk_size() const {
-  // Implementation goes here
-  return 0;
+ChunkOffset Table::target_chunk_size() const { return _target_chunk_size; }
+
+const std::vector<std::string>& Table::column_names() const { return _column_names; }
+
+const std::string& Table::column_name(const ColumnID column_id) const { return _column_names.at(column_id); }
+
+const std::string& Table::column_type(const ColumnID column_id) const { return _column_types.at(column_id); }
+
+Chunk& Table::get_chunk(ChunkID chunk_id) { return *_chunks.at(chunk_id); }
+
+const Chunk& Table::get_chunk(ChunkID chunk_id) const { return *_chunks.at(chunk_id); }
+
+void Table::_add_value_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type) {
+  resolve_data_type(type, [&](const auto data_type_t) {
+    using ColumnDataType = typename decltype(data_type_t)::type;
+    const auto value_segment = std::make_shared<ValueSegment<ColumnDataType>>();
+    chunk->add_segment(value_segment);
+  });
 }
-
-const std::vector<std::string>& Table::column_names() const {
-  throw std::runtime_error("Implement Table::column_names()");
-}
-
-const std::string& Table::column_name(const ColumnID column_id) const {
-  throw std::runtime_error("Implement Table::column_name");
-}
-
-const std::string& Table::column_type(const ColumnID column_id) const {
-  throw std::runtime_error("Implement Table::column_type");
-}
-
-Chunk& Table::get_chunk(ChunkID chunk_id) { throw std::runtime_error("Implement Table::get_chunk"); }
-
-const Chunk& Table::get_chunk(ChunkID chunk_id) const { throw std::runtime_error("Implement Table::get_chunk"); }
 
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -91,7 +91,7 @@ class Table : private Noncopyable {
   std::mutex _add_segment_lock;
 
   void _add_value_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type);
-  void _add_dictionary_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type,
-                                        const std::shared_ptr<BaseSegment>& value_segment);
+  void _add_dictionary_segment_to_vector(std::vector<std::shared_ptr<BaseSegment>>& compressed_segments, const std::string& type,
+                                             const std::shared_ptr<BaseSegment>& segment, const ColumnID column_id);
 };
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -72,6 +72,11 @@ class Table : private Noncopyable {
   void append(const std::vector<AllTypeVariant>& values);
 
  protected:
-  // Implementation goes here
+  std::vector<std::shared_ptr<Chunk>> _chunks;
+  ChunkOffset _target_chunk_size;
+  std::vector<std::string> _column_names;
+  std::vector<std::string> _column_types;
+
+  void _add_value_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type);
 };
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -81,5 +81,7 @@ class Table : private Noncopyable {
   std::vector<std::string> _column_types;
 
   void _add_value_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type);
+  void _add_dictionary_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type,
+                                        const std::shared_ptr<BaseSegment>& value_segment);
 };
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -80,6 +80,8 @@ class Table : private Noncopyable {
   std::vector<std::string> _column_names;
   std::vector<std::string> _column_types;
 
+  std::mutex _add_segment_lock;
+
   void _add_value_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type);
   void _add_dictionary_segment_to_chunk(std::shared_ptr<Chunk>& chunk, const std::string& type,
                                         const std::shared_ptr<BaseSegment>& value_segment);

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -34,7 +34,7 @@ const std::vector<T>& ValueSegment<T>::values() const {
 
 template <typename T>
 size_t ValueSegment<T>::estimate_memory_usage() const {
-  return (sizeof(T)*_values.size());
+  return (sizeof(T) * _values.size());
 }
 
 EXPLICITLY_INSTANTIATE_DATA_TYPES(ValueSegment);

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -14,18 +14,22 @@ namespace opossum {
 
 template <typename T>
 AllTypeVariant ValueSegment<T>::operator[](const ChunkOffset chunk_offset) const {
-  throw std::runtime_error("Implement ValueSegment::operator[]");
+  return static_cast<AllTypeVariant>(_values.at(chunk_offset));
 }
 
 template <typename T>
 void ValueSegment<T>::append(const AllTypeVariant& val) {
-  // Implementation goes here
+  _values.push_back(type_cast<T>(val));
 }
 
 template <typename T>
 ChunkOffset ValueSegment<T>::size() const {
-  // Implementation goes here
-  return 0;
+  return static_cast<ChunkOffset>(_values.size());
+}
+
+template <typename T>
+const std::vector<T>& ValueSegment<T>::values() const {
+  return _values;
 }
 
 EXPLICITLY_INSTANTIATE_DATA_TYPES(ValueSegment);

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -34,8 +34,7 @@ const std::vector<T>& ValueSegment<T>::values() const {
 
 template <typename T>
 size_t ValueSegment<T>::estimate_memory_usage() const {
-  // Implementation goes here
-  return 0;
+  return (sizeof(T)*_values.size());
 }
 
 EXPLICITLY_INSTANTIATE_DATA_TYPES(ValueSegment);

--- a/src/lib/storage/value_segment.hpp
+++ b/src/lib/storage/value_segment.hpp
@@ -28,7 +28,7 @@ class ValueSegment : public BaseSegment {
   const std::vector<T>& values() const;
 
  protected:
-  // Implementation goes here
+  std::vector<T> _values;
 };
 
 }  // namespace opossum

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -10,52 +10,55 @@
 
 namespace opossum {
 
-// class StorageChunkTest : public BaseTest {
-//  protected:
-//   void SetUp() override {
-//     int_value_segment = std::make_shared<ValueSegment<int32_t>>();
-//     int_value_segment->append(4);
-//     int_value_segment->append(6);
-//     int_value_segment->append(3);
+class StorageChunkTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    int_value_segment = std::make_shared<ValueSegment<int32_t>>();
+    int_value_segment->append(4);
+    int_value_segment->append(6);
+    int_value_segment->append(3);
 
-//     string_value_segment = std::make_shared<ValueSegment<std::string>>();
-//     string_value_segment->append("Hello,");
-//     string_value_segment->append("world");
-//     string_value_segment->append("!");
-//   }
+    string_value_segment = std::make_shared<ValueSegment<std::string>>();
+    string_value_segment->append("Hello,");
+    string_value_segment->append("world");
+    string_value_segment->append("!");
+  }
 
-//   Chunk c;
-//   std::shared_ptr<BaseSegment> int_value_segment = nullptr;
-//   std::shared_ptr<BaseSegment> string_value_segment = nullptr;
-// };
+  Chunk c;
+  std::shared_ptr<BaseSegment> int_value_segment = nullptr;
+  std::shared_ptr<BaseSegment> string_value_segment = nullptr;
+};
 
-// TEST_F(StorageChunkTest, AddSegmentToChunk) {
-//   EXPECT_EQ(c.size(), 0u);
-//   c.add_segment(int_value_segment);
-//   c.add_segment(string_value_segment);
-//   EXPECT_EQ(c.size(), 3u);
-// }
+TEST_F(StorageChunkTest, AddSegmentToChunk) {
+  EXPECT_EQ(c.size(), 0u);
+  EXPECT_EQ(c.column_count(), 0u);
+  c.add_segment(int_value_segment);
+  c.add_segment(string_value_segment);
+  EXPECT_EQ(c.column_count(), 2u);
+  EXPECT_EQ(c.size(), 3u);
+}
 
-// TEST_F(StorageChunkTest, AddValuesToChunk) {
-//   c.add_segment(int_value_segment);
-//   c.add_segment(string_value_segment);
-//   c.append({2, "two"});
-//   EXPECT_EQ(c.size(), 4u);
+TEST_F(StorageChunkTest, AddValuesToChunk) {
+  c.add_segment(int_value_segment);
+  c.add_segment(string_value_segment);
+  c.append({2, "two"});
+  EXPECT_EQ(c.size(), 4u);
 
-//   if constexpr (HYRISE_DEBUG) {
-//     EXPECT_THROW(c.append({}), std::exception);
-//     EXPECT_THROW(c.append({4, "val", 3}), std::exception);
-//     EXPECT_EQ(c.size(), 4u);
-//   }
-// }
+  if constexpr (HYRISE_DEBUG) {
+    EXPECT_THROW(c.append({}), std::exception);
+    EXPECT_THROW(c.append({4, "val", 3}), std::exception);
+    EXPECT_EQ(c.size(), 4u);
+  }
+}
 
-// TEST_F(StorageChunkTest, RetrieveSegment) {
-//   c.add_segment(int_value_segment);
-//   c.add_segment(string_value_segment);
-//   c.append({2, "two"});
+TEST_F(StorageChunkTest, RetrieveSegment) {
+  c.add_segment(int_value_segment);
+  c.add_segment(string_value_segment);
+  c.append({2, "two"});
 
-//   auto base_segment = c.get_segment(ColumnID{0});
-//   EXPECT_EQ(base_segment->size(), 4u);
-// }
+  auto base_segment = c.get_segment(ColumnID{0});
+  EXPECT_EQ(base_segment->size(), 4u);
+  EXPECT_EQ((*base_segment)[3], static_cast<AllTypeVariant>(2));
+}
 
 }  // namespace opossum

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -22,11 +22,18 @@ class StorageChunkTest : public BaseTest {
     string_value_segment->append("Hello,");
     string_value_segment->append("world");
     string_value_segment->append("!");
+
+    int_value_segment_4_elements = std::make_shared<ValueSegment<int32_t>>();
+    int_value_segment_4_elements->append(4);
+    int_value_segment_4_elements->append(6);
+    int_value_segment_4_elements->append(3);
+    int_value_segment_4_elements->append(3);
   }
 
   Chunk c;
   std::shared_ptr<BaseSegment> int_value_segment = nullptr;
   std::shared_ptr<BaseSegment> string_value_segment = nullptr;
+  std::shared_ptr<BaseSegment> int_value_segment_4_elements = nullptr;
 };
 
 TEST_F(StorageChunkTest, AddSegmentToChunk) {
@@ -36,6 +43,8 @@ TEST_F(StorageChunkTest, AddSegmentToChunk) {
   c.add_segment(string_value_segment);
   EXPECT_EQ(c.column_count(), 2u);
   EXPECT_EQ(c.size(), 3u);
+
+  EXPECT_THROW(c.add_segment(int_value_segment_4_elements), std::exception);
 }
 
 TEST_F(StorageChunkTest, AddValuesToChunk) {

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -48,6 +48,10 @@ TEST_F(StorageDictionarySegmentTest, CompressStringSegment) {
   EXPECT_EQ(dict_col->get(0), "Bill");
   EXPECT_EQ(dict_col->get(5), "Bill");
   EXPECT_THROW(dict_col->get(6), std::exception);
+
+  EXPECT_EQ((*dict_col)[0], static_cast<AllTypeVariant>("Bill"));
+  EXPECT_EQ((*dict_col)[5], static_cast<AllTypeVariant>("Bill"));
+  EXPECT_THROW((*dict_col)[6], std::exception);
 }
 
 TEST_F(StorageDictionarySegmentTest, LowerUpperBound) {

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -48,10 +48,6 @@ TEST_F(StorageDictionarySegmentTest, CompressStringSegment) {
   EXPECT_EQ(dict_col->get(0), "Bill");
   EXPECT_EQ(dict_col->get(5), "Bill");
   EXPECT_THROW(dict_col->get(6), std::exception);
-
-  EXPECT_EQ((*dict_col)[0], static_cast<AllTypeVariant>("Bill"));
-  EXPECT_EQ((*dict_col)[5], static_cast<AllTypeVariant>("Bill"));
-  EXPECT_THROW((*dict_col)[6], std::exception);
 }
 
 TEST_F(StorageDictionarySegmentTest, LowerUpperBound) {

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -67,4 +67,20 @@ TEST_F(StorageDictionarySegmentTest, LowerUpperBound) {
 
 // TODO(student): You should add some more tests here (full coverage would be appreciated) and possibly in other files.
 
+TEST_F(StorageDictionarySegmentTest, MemoryEstimation) {
+  for (int i = 0; i < 300; i += 1) vc_int->append(i);
+
+  std::shared_ptr<BaseSegment> col;
+  resolve_data_type("int", [&](auto type) {
+    using Type = typename decltype(type)::type;
+    col = std::make_shared<DictionarySegment<Type>>(vc_int);
+  });
+  auto dict_col = std::dynamic_pointer_cast<opossum::DictionarySegment<int>>(col);
+
+  // 300 elements with 4 bytes (byte size of an int) per element for the value segment
+  EXPECT_EQ(vc_int->estimate_memory_usage(), 1200);
+
+  // 300 elements * 4 byte per int from the dictionary + 300 elements * 2 byte (uint16_t) from the attribute vector
+  EXPECT_EQ(dict_col->estimate_memory_usage(), 1800);
+}
 }  // namespace opossum

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -106,7 +106,6 @@ TEST_F(StorageDictionarySegmentTest, UseFixedSizeAttributeVector) {
   auto attribute_vector_3 = dict_col_3->attribute_vector();
 
   EXPECT_EQ(attribute_vector_3->width(), 4);
-
 }
 
 TEST_F(StorageDictionarySegmentTest, MemoryEstimation) {
@@ -143,7 +142,7 @@ TEST_F(StorageDictionarySegmentTest, MemoryEstimation) {
   EXPECT_EQ(vc_str->estimate_memory_usage() > dict_col_str->estimate_memory_usage(), true);
 }
 
-TEST_F(StorageDictionarySegmentTest, MemoryEstimation2) {
+TEST_F(StorageDictionarySegmentTest, AppendRow) {
   for (int i = 0; i < 300; i += 1) vc_int->append(i);
 
   std::shared_ptr<BaseSegment> col;
@@ -153,28 +152,8 @@ TEST_F(StorageDictionarySegmentTest, MemoryEstimation2) {
   });
   auto dict_col_int = std::dynamic_pointer_cast<opossum::DictionarySegment<int>>(col);
 
-  // 300 elements with 4 bytes (byte size of an int) per element for the value segment
-  EXPECT_EQ(vc_int->estimate_memory_usage(), 1200);
-
-  // 300 elements * 4 byte per int from the dictionary + 300 elements * 2 byte (uint16_t) from the attribute vector
-  EXPECT_EQ(dict_col_int->estimate_memory_usage(), 1800);
-
-  vc_str->append("Bill");
-  vc_str->append("Steve");
-  vc_str->append("Alexander");
-  vc_str->append("Steve");
-  vc_str->append("Hasso");
-  vc_str->append("Bill");
-
-  std::shared_ptr<BaseSegment> col_2;
-  resolve_data_type("string", [&](auto type) {
-    using Type = typename decltype(type)::type;
-    col_2 = std::make_shared<DictionarySegment<Type>>(vc_str);
-  });
-  auto dict_col_str = std::dynamic_pointer_cast<opossum::DictionarySegment<std::string>>(col_2);
-
-  // should be smaller, since we reduced number of strings we need to store
-  EXPECT_EQ(vc_str->estimate_memory_usage() > dict_col_str->estimate_memory_usage(), true);
+  const auto value = static_cast<AllTypeVariant>(0);
+  EXPECT_THROW(dict_col_int->append(value), std::exception);
 }
 
 }  // namespace opossum

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -10,60 +10,60 @@
 
 namespace opossum {
 
-// class StorageDictionarySegmentTest : public ::testing::Test {
-//  protected:
-//   std::shared_ptr<opossum::ValueSegment<int>> vc_int = std::make_shared<opossum::ValueSegment<int>>();
-//   std::shared_ptr<opossum::ValueSegment<std::string>> vc_str = std::make_shared<opossum::ValueSegment<std::string>>();
-// };
+class StorageDictionarySegmentTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<opossum::ValueSegment<int>> vc_int = std::make_shared<opossum::ValueSegment<int>>();
+  std::shared_ptr<opossum::ValueSegment<std::string>> vc_str = std::make_shared<opossum::ValueSegment<std::string>>();
+};
 
-// TEST_F(StorageDictionarySegmentTest, CompressSegmentString) {
-//   vc_str->append("Bill");
-//   vc_str->append("Steve");
-//   vc_str->append("Alexander");
-//   vc_str->append("Steve");
-//   vc_str->append("Hasso");
-//   vc_str->append("Bill");
+TEST_F(StorageDictionarySegmentTest, CompressSegmentString) {
+  vc_str->append("Bill");
+  vc_str->append("Steve");
+  vc_str->append("Alexander");
+  vc_str->append("Steve");
+  vc_str->append("Hasso");
+  vc_str->append("Bill");
 
-//   std::shared_ptr<BaseSegment> col;
-//   resolve_data_type("string", [&](auto type) {
-//     using Type = typename decltype(type)::type;
-//     col = std::make_shared<DictionarySegment<Type>>(vc_str);
-//   });
-//   auto dict_col = std::dynamic_pointer_cast<opossum::DictionarySegment<std::string>>(col);
+  std::shared_ptr<BaseSegment> col;
+  resolve_data_type("string", [&](auto type) {
+    using Type = typename decltype(type)::type;
+    col = std::make_shared<DictionarySegment<Type>>(vc_str);
+  });
+  auto dict_col = std::dynamic_pointer_cast<opossum::DictionarySegment<std::string>>(col);
 
-//   // Test attribute_vector size
-//   EXPECT_EQ(dict_col->size(), 6u);
+  // Test attribute_vector size
+  EXPECT_EQ(dict_col->size(), 6u);
 
-//   // Test dictionary size (uniqueness)
-//   EXPECT_EQ(dict_col->unique_values_count(), 4u);
+  // Test dictionary size (uniqueness)
+  EXPECT_EQ(dict_col->unique_values_count(), 4u);
 
-//   // Test sorting
-//   auto dict = dict_col->dictionary();
-//   EXPECT_EQ((*dict)[0], "Alexander");
-//   EXPECT_EQ((*dict)[1], "Bill");
-//   EXPECT_EQ((*dict)[2], "Hasso");
-//   EXPECT_EQ((*dict)[3], "Steve");
-// }
+  // Test sorting
+  auto dict = dict_col->dictionary();
+  EXPECT_EQ((*dict)[0], "Alexander");
+  EXPECT_EQ((*dict)[1], "Bill");
+  EXPECT_EQ((*dict)[2], "Hasso");
+  EXPECT_EQ((*dict)[3], "Steve");
+}
 
-// TEST_F(StorageDictionarySegmentTest, LowerUpperBound) {
-//   for (int i = 0; i <= 10; i += 2) vc_int->append(i);
+TEST_F(StorageDictionarySegmentTest, LowerUpperBound) {
+  for (int i = 0; i <= 10; i += 2) vc_int->append(i);
 
-//   std::shared_ptr<BaseSegment> col;
-//   resolve_data_type("int", [&](auto type) {
-//     using Type = typename decltype(type)::type;
-//     col = std::make_shared<DictionarySegment<Type>>(vc_str);
-//   });
-//   auto dict_col = std::dynamic_pointer_cast<opossum::DictionarySegment<int>>(col);
+  std::shared_ptr<BaseSegment> col;
+  resolve_data_type("int", [&](auto type) {
+    using Type = typename decltype(type)::type;
+    col = std::make_shared<DictionarySegment<Type>>(vc_str);
+  });
+  auto dict_col = std::dynamic_pointer_cast<opossum::DictionarySegment<int>>(col);
 
-//   EXPECT_EQ(dict_col->lower_bound(4), (opossum::ValueID)2);
-//   EXPECT_EQ(dict_col->upper_bound(4), (opossum::ValueID)3);
+  EXPECT_EQ(dict_col->lower_bound(4), (opossum::ValueID)2);
+  EXPECT_EQ(dict_col->upper_bound(4), (opossum::ValueID)3);
 
-//   EXPECT_EQ(dict_col->lower_bound(5), (opossum::ValueID)3);
-//   EXPECT_EQ(dict_col->upper_bound(5), (opossum::ValueID)3);
+  EXPECT_EQ(dict_col->lower_bound(5), (opossum::ValueID)3);
+  EXPECT_EQ(dict_col->upper_bound(5), (opossum::ValueID)3);
 
-//   EXPECT_EQ(dict_col->lower_bound(15), opossum::INVALID_VALUE_ID);
-//   EXPECT_EQ(dict_col->upper_bound(15), opossum::INVALID_VALUE_ID);
-// }
+  EXPECT_EQ(dict_col->lower_bound(15), opossum::INVALID_VALUE_ID);
+  EXPECT_EQ(dict_col->upper_bound(15), opossum::INVALID_VALUE_ID);
+}
 
 // TODO(student): You should add some more tests here (full coverage would be appreciated) and possibly in other files.
 

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -156,4 +156,18 @@ TEST_F(StorageDictionarySegmentTest, AppendRow) {
   EXPECT_THROW(dict_col_int->append(value), std::exception);
 }
 
+TEST_F(StorageDictionarySegmentTest, GetValueByValueId) {
+  for (int i = 0; i < 10; i += 1) vc_int->append(i);
+
+  std::shared_ptr<BaseSegment> col;
+  resolve_data_type("int", [&](auto type) {
+    using Type = typename decltype(type)::type;
+    col = std::make_shared<DictionarySegment<Type>>(vc_int);
+  });
+  auto dict_col_int = std::dynamic_pointer_cast<opossum::DictionarySegment<int>>(col);
+
+  EXPECT_EQ(dict_col_int->value_by_value_id(static_cast<ValueID>(5)), 5);
+  EXPECT_NE(dict_col_int->value_by_value_id(static_cast<ValueID>(7)), 8);
+}
+
 }  // namespace opossum

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -51,7 +51,7 @@ TEST_F(StorageDictionarySegmentTest, LowerUpperBound) {
   std::shared_ptr<BaseSegment> col;
   resolve_data_type("int", [&](auto type) {
     using Type = typename decltype(type)::type;
-    col = std::make_shared<DictionarySegment<Type>>(vc_str);
+    col = std::make_shared<DictionarySegment<Type>>(vc_int);
   });
   auto dict_col = std::dynamic_pointer_cast<opossum::DictionarySegment<int>>(col);
 

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -8,46 +8,46 @@
 
 namespace opossum {
 
-// class StorageStorageManagerTest : public BaseTest {
-//  protected:
-//   void SetUp() override {
-//     auto& sm = StorageManager::get();
-//     auto t1 = std::make_shared<Table>();
-//     auto t2 = std::make_shared<Table>(4);
+class StorageStorageManagerTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    auto& sm = StorageManager::get();
+    auto t1 = std::make_shared<Table>();
+    auto t2 = std::make_shared<Table>(4);
 
-//     sm.add_table("first_table", t1);
-//     sm.add_table("second_table", t2);
-//   }
-// };
+    sm.add_table("first_table", t1);
+    sm.add_table("second_table", t2);
+  }
+};
 
-// TEST_F(StorageStorageManagerTest, GetTable) {
-//   auto& sm = StorageManager::get();
-//   auto t3 = sm.get_table("first_table");
-//   auto t4 = sm.get_table("second_table");
-//   EXPECT_THROW(sm.get_table("third_table"), std::exception);
-// }
+TEST_F(StorageStorageManagerTest, GetTable) {
+  auto& sm = StorageManager::get();
+  auto t3 = sm.get_table("first_table");
+  auto t4 = sm.get_table("second_table");
+  EXPECT_THROW(sm.get_table("third_table"), std::exception);
+}
 
-// TEST_F(StorageStorageManagerTest, DropTable) {
-//   auto& sm = StorageManager::get();
-//   sm.drop_table("first_table");
-//   EXPECT_THROW(sm.get_table("first_table"), std::exception);
-//   EXPECT_THROW(sm.drop_table("first_table"), std::exception);
-// }
+TEST_F(StorageStorageManagerTest, DropTable) {
+  auto& sm = StorageManager::get();
+  sm.drop_table("first_table");
+  EXPECT_THROW(sm.get_table("first_table"), std::exception);
+  EXPECT_THROW(sm.drop_table("first_table"), std::exception);
+}
 
-// TEST_F(StorageStorageManagerTest, ResetTable) {
-//   StorageManager::get().reset();
-//   auto& sm = StorageManager::get();
-//   EXPECT_THROW(sm.get_table("first_table"), std::exception);
-// }
+TEST_F(StorageStorageManagerTest, ResetTable) {
+  StorageManager::get().reset();
+  auto& sm = StorageManager::get();
+  EXPECT_THROW(sm.get_table("first_table"), std::exception);
+}
 
-// TEST_F(StorageStorageManagerTest, DoesNotHaveTable) {
-//   auto& sm = StorageManager::get();
-//   EXPECT_EQ(sm.has_table("third_table"), false);
-// }
+TEST_F(StorageStorageManagerTest, DoesNotHaveTable) {
+  auto& sm = StorageManager::get();
+  EXPECT_EQ(sm.has_table("third_table"), false);
+}
 
-// TEST_F(StorageStorageManagerTest, HasTable) {
-//   auto& sm = StorageManager::get();
-//   EXPECT_EQ(sm.has_table("first_table"), true);
-// }
+TEST_F(StorageStorageManagerTest, HasTable) {
+  auto& sm = StorageManager::get();
+  EXPECT_EQ(sm.has_table("first_table"), true);
+}
 
 }  // namespace opossum

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -14,7 +14,7 @@ class StorageStorageManagerTest : public BaseTest {
  protected:
   void SetUp() override {
     auto& sm = StorageManager::get();
-    auto t1 = std::make_shared<Table>();
+    auto t1 = std::make_shared<Table>(1);
     auto t2 = std::make_shared<Table>(4);
 
     sm.add_table("first_table", t1);
@@ -34,8 +34,12 @@ TEST_F(StorageStorageManagerTest, AddTable) {
 
 TEST_F(StorageStorageManagerTest, GetTable) {
   auto& sm = StorageManager::get();
-  auto t3 = sm.get_table("first_table");
-  auto t4 = sm.get_table("second_table");
+  auto t1 = sm.get_table("first_table");
+  EXPECT_EQ(t1->target_chunk_size(), 1u);
+
+  auto t2 = sm.get_table("second_table");
+  EXPECT_EQ(t2->target_chunk_size(), 4u);
+
   EXPECT_THROW(sm.get_table("third_table"), std::exception);
 }
 
@@ -60,7 +64,6 @@ TEST_F(StorageStorageManagerTest, DoesNotHaveTable) {
 TEST_F(StorageStorageManagerTest, HasTable) {
   auto& sm = StorageManager::get();
   EXPECT_EQ(sm.has_table("first_table"), true);
-  EXPECT_EQ(sm.has_table("some_other_table"), false);
 }
 
 TEST_F(StorageStorageManagerTest, GetTableNames) {
@@ -74,7 +77,9 @@ TEST_F(StorageStorageManagerTest, GetTableNames) {
 TEST_F(StorageStorageManagerTest, PrintTable) {
   auto& sm = StorageManager::get();
   sm.drop_table("second_table");
-  std::string expected = "first_table #columns: 0 #rows: 0 #chunks: 1\n";
+  const std::string expected =
+      "StorageManager #tables: 1\n"
+      "first_table #columns: 0 #rows: 0 #chunks: 1\n";
 
   std::stringstream buffer;
   std::streambuf* prevcoutbuf = std::cout.rdbuf(buffer.rdbuf());

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -1,4 +1,6 @@
 #include <memory>
+#include <iostream>
+#include <sstream>
 
 #include "../base_test.hpp"
 #include "gtest/gtest.h"
@@ -19,6 +21,16 @@ class StorageStorageManagerTest : public BaseTest {
     sm.add_table("second_table", t2);
   }
 };
+
+TEST_F(StorageStorageManagerTest, AddTable) {
+  auto& sm = StorageManager::get();
+  auto t3 = std::make_shared<Table>();
+
+  sm.add_table("third_table", t3);
+  EXPECT_EQ(sm.table_names().size(), 3u);
+
+  EXPECT_THROW(sm.add_table("first_table", t3), std::exception);
+}
 
 TEST_F(StorageStorageManagerTest, GetTable) {
   auto& sm = StorageManager::get();
@@ -48,6 +60,31 @@ TEST_F(StorageStorageManagerTest, DoesNotHaveTable) {
 TEST_F(StorageStorageManagerTest, HasTable) {
   auto& sm = StorageManager::get();
   EXPECT_EQ(sm.has_table("first_table"), true);
+  EXPECT_EQ(sm.has_table("some_other_table"), false);
+}
+
+TEST_F(StorageStorageManagerTest, GetTableNames) {
+  std::vector<std::string> sm_table_names = StorageManager::get().table_names();
+
+  std::sort(sm_table_names.begin(), sm_table_names.end());
+
+  EXPECT_EQ(sm_table_names, std::vector<std::string>({"first_table", "second_table"}));
+}
+
+TEST_F(StorageStorageManagerTest, PrintTable) {
+  auto& sm = StorageManager::get();
+  sm.drop_table("second_table");
+  std::string expected = "first_table #columns: 0 #rows: 0 #chunks: 1\n";
+
+  std::stringstream buffer;
+  std::streambuf* prevcoutbuf = std::cout.rdbuf(buffer.rdbuf());
+
+  sm.print();
+  std::string printed_text = buffer.str();
+  // Restore original buffer before exiting
+  std::cout.rdbuf(prevcoutbuf);
+  
+  EXPECT_EQ(printed_text, expected);
 }
 
 }  // namespace opossum

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -1,5 +1,5 @@
-#include <memory>
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include "../base_test.hpp"
@@ -83,7 +83,7 @@ TEST_F(StorageStorageManagerTest, PrintTable) {
   std::string printed_text = buffer.str();
   // Restore original buffer before exiting
   std::cout.rdbuf(prevcoutbuf);
-  
+
   EXPECT_EQ(printed_text, expected);
 }
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -12,63 +12,63 @@
 
 namespace opossum {
 
-// class StorageTableTest : public BaseTest {
-//  protected:
-//   void SetUp() override {
-//     t.add_column("col_1", "int");
-//     t.add_column("col_2", "string");
-//   }
+class StorageTableTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    t.add_column("col_1", "int");
+    t.add_column("col_2", "string");
+  }
 
-//   Table t{2};
-// };
+  Table t{2};
+};
 
-// TEST_F(StorageTableTest, ChunkCount) {
-//   EXPECT_EQ(t.chunk_count(), 1u);
-//   t.append({4, "Hello,"});
-//   t.append({6, "world"});
-//   t.append({3, "!"});
-//   EXPECT_EQ(t.chunk_count(), 2u);
-// }
+TEST_F(StorageTableTest, ChunkCount) {
+  EXPECT_EQ(t.chunk_count(), 1u);
+  t.append({4, "Hello,"});
+  t.append({6, "world"});
+  t.append({3, "!"});
+  EXPECT_EQ(t.chunk_count(), 2u);
+}
 
-// TEST_F(StorageTableTest, GetChunk) {
-//   t.get_chunk(ChunkID{0});
-//   // TODO(anyone): Do we want checks here?
-//   // EXPECT_THROW(t.get_chunk(ChunkID{q}), std::exception);
-//   t.append({4, "Hello,"});
-//   t.append({6, "world"});
-//   t.append({3, "!"});
-//   t.get_chunk(ChunkID{1});
-// }
+TEST_F(StorageTableTest, GetChunk) {
+  t.get_chunk(ChunkID{0});
+  // TODO(anyone): Do we want checks here?
+  // EXPECT_THROW(t.get_chunk(ChunkID{q}), std::exception);
+  t.append({4, "Hello,"});
+  t.append({6, "world"});
+  t.append({3, "!"});
+  t.get_chunk(ChunkID{1});
+}
 
-// TEST_F(StorageTableTest, ColumnCount) { EXPECT_EQ(t.column_count(), 2u); }
+TEST_F(StorageTableTest, ColumnCount) { EXPECT_EQ(t.column_count(), 2u); }
 
-// TEST_F(StorageTableTest, RowCount) {
-//   EXPECT_EQ(t.row_count(), 0u);
-//   t.append({4, "Hello,"});
-//   t.append({6, "world"});
-//   t.append({3, "!"});
-//   EXPECT_EQ(t.row_count(), 3u);
-// }
+TEST_F(StorageTableTest, RowCount) {
+  EXPECT_EQ(t.row_count(), 0u);
+  t.append({4, "Hello,"});
+  t.append({6, "world"});
+  t.append({3, "!"});
+  EXPECT_EQ(t.row_count(), 3u);
+}
 
-// TEST_F(StorageTableTest, GetColumnName) {
-//   EXPECT_EQ(t.column_name(ColumnID{0}), "col_1");
-//   EXPECT_EQ(t.column_name(ColumnID{1}), "col_2");
-//   // TODO(anyone): Do we want checks here?
-//   // EXPECT_THROW(t.column_name(ColumnID{2}), std::exception);
-// }
+TEST_F(StorageTableTest, GetColumnName) {
+  EXPECT_EQ(t.column_name(ColumnID{0}), "col_1");
+  EXPECT_EQ(t.column_name(ColumnID{1}), "col_2");
+  // TODO(anyone): Do we want checks here?
+  // EXPECT_THROW(t.column_name(ColumnID{2}), std::exception);
+}
 
-// TEST_F(StorageTableTest, GetColumnType) {
-//   EXPECT_EQ(t.column_type(ColumnID{0}), "int");
-//   EXPECT_EQ(t.column_type(ColumnID{1}), "string");
-//   // TODO(anyone): Do we want checks here?
-//   // EXPECT_THROW(t.column_type(ColumnID{2}), std::exception);
-// }
+TEST_F(StorageTableTest, GetColumnType) {
+  EXPECT_EQ(t.column_type(ColumnID{0}), "int");
+  EXPECT_EQ(t.column_type(ColumnID{1}), "string");
+  // TODO(anyone): Do we want checks here?
+  // EXPECT_THROW(t.column_type(ColumnID{2}), std::exception);
+}
 
-// TEST_F(StorageTableTest, GetColumnIdByName) {
-//   EXPECT_EQ(t.column_id_by_name("col_2"), 1u);
-//   EXPECT_THROW(t.column_id_by_name("no_column_name"), std::exception);
-// }
+TEST_F(StorageTableTest, GetColumnIdByName) {
+  EXPECT_EQ(t.column_id_by_name("col_2"), 1u);
+  EXPECT_THROW(t.column_id_by_name("no_column_name"), std::exception);
+}
 
-// TEST_F(StorageTableTest, GetChunkSize) { EXPECT_EQ(t.target_chunk_size(), 2u); }
+TEST_F(StorageTableTest, GetChunkSize) { EXPECT_EQ(t.target_chunk_size(), 2u); }
 
 }  // namespace opossum

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -87,33 +87,42 @@ TEST_F(StorageTableTest, GetColumnIdByName) {
 TEST_F(StorageTableTest, GetChunkSize) { EXPECT_EQ(t.target_chunk_size(), 2u); }
 
 TEST_F(StorageTableTest, EmplaceChunk) {
-  // auto int_value_segment = std::make_shared<ValueSegment<int32_t>>();
-  // int_value_segment->append(4);
-  // int_value_segment->append(6);
-  // int_value_segment->append(3);
+  auto int_value_segment = std::make_shared<ValueSegment<int32_t>>();
+  int_value_segment->append(4);
+  int_value_segment->append(6);
+  int_value_segment->append(3);
 
-  // auto string_value_segment = std::make_shared<ValueSegment<std::string>>();
-  // string_value_segment->append("Hello,");
-  // string_value_segment->append("world");
-  // string_value_segment->append("!");
+  auto string_value_segment = std::make_shared<ValueSegment<std::string>>();
+  string_value_segment->append("Hello,");
+  string_value_segment->append("world");
+  string_value_segment->append("!");
 
-  // Chunk c;
+  Chunk c;
 
-  // c.add_segment(int_value_segment);
-  // c.add_segment(string_value_segment);
+  c.add_segment(int_value_segment);
 
-  // construct a chunk
-  // emplace chunk -> error because wrong number of columns
-  // add columns to table
-  // emplace chunk -> should replace current chunk -> number chunks == 1
-  // append
-  // append
-  // emplace chunk -> append chunk => number chunks >= 2 (depends on appends earlier)
-  // test whether row size is correct!
+  // error because wrong number of columns
+  EXPECT_THROW(t.emplace_chunk(std::move(c)), std::exception);
 
-  // test whether false number of columns results in error
-  // emplace chunk when first chunk is empty
-  // emplace chunk when we already have written chunks
+  Chunk c2;
+  c2.add_segment(int_value_segment);
+  c2.add_segment(string_value_segment);
+  EXPECT_EQ(t.chunk_count(), 1u);
+  t.emplace_chunk(std::move(c2));
+  EXPECT_EQ(t.chunk_count(), 1u);
+
+  t.append({4, "Hello,"});
+  t.append({6, "world"});
+  t.append({3, "!"});
+  EXPECT_EQ(t.chunk_count(), 3u);
+  EXPECT_EQ(t.row_count(), 6u);
+
+  Chunk c3;
+  c3.add_segment(int_value_segment);
+  c3.add_segment(string_value_segment);
+  t.emplace_chunk(std::move(c3));
+  EXPECT_EQ(t.chunk_count(), 4u);
+  EXPECT_EQ(t.row_count(), 9u);
 }
 
 TEST_F(StorageTableTest, CompressChunk) {

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -86,4 +86,56 @@ TEST_F(StorageTableTest, GetColumnIdByName) {
 
 TEST_F(StorageTableTest, GetChunkSize) { EXPECT_EQ(t.target_chunk_size(), 2u); }
 
+TEST_F(StorageTableTest, EmplaceChunk) {
+  // auto int_value_segment = std::make_shared<ValueSegment<int32_t>>();
+  // int_value_segment->append(4);
+  // int_value_segment->append(6);
+  // int_value_segment->append(3);
+
+  // auto string_value_segment = std::make_shared<ValueSegment<std::string>>();
+  // string_value_segment->append("Hello,");
+  // string_value_segment->append("world");
+  // string_value_segment->append("!");
+
+  // Chunk c;
+
+  // c.add_segment(int_value_segment);
+  // c.add_segment(string_value_segment);
+
+  // construct a chunk
+  // emplace chunk -> error because wrong number of columns
+  // add columns to table
+  // emplace chunk -> should replace current chunk -> number chunks == 1
+  // append
+  // append
+  // emplace chunk -> append chunk => number chunks >= 2 (depends on appends earlier)
+  // test whether row size is correct!
+
+  // test whether false number of columns results in error
+  // emplace chunk when first chunk is empty
+  // emplace chunk when we already have written chunks
+}
+
+TEST_F(StorageTableTest, CompressChunk) {
+  EXPECT_EQ(t.chunk_count(), 1u);
+  t.append({4, "Hello,"});
+  t.append({6, "world"});
+  t.append({3, "!"});
+  EXPECT_EQ(t.chunk_count(), 2u);
+
+  // check whether insertion was correct
+  const auto& chunk_1 = t.get_chunk(ChunkID{0});
+  const auto& segment_1 = chunk_1.get_segment(ColumnID{0});
+  const auto value_1 = (*segment_1)[0];
+  EXPECT_EQ(type_cast<int>(value_1), 4);
+
+  t.compress_chunk(ChunkID{0});
+
+  // check that compression didn't change anything
+  const auto& chunk_2 = t.get_chunk(ChunkID{0});
+  const auto& segment_2 = chunk_2.get_segment(ColumnID{0});
+  const auto value_2 = (*segment_2)[0];
+  EXPECT_EQ(type_cast<int>(value_2), 4);
+}
+
 }  // namespace opossum

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -32,12 +32,20 @@ TEST_F(StorageTableTest, ChunkCount) {
 
 TEST_F(StorageTableTest, GetChunk) {
   t.get_chunk(ChunkID{0});
-  // TODO(anyone): Do we want checks here?
-  // EXPECT_THROW(t.get_chunk(ChunkID{q}), std::exception);
+  EXPECT_THROW(t.get_chunk(ChunkID{7}), std::exception);
   t.append({4, "Hello,"});
   t.append({6, "world"});
   t.append({3, "!"});
   t.get_chunk(ChunkID{1});
+  std::as_const(t).get_chunk(ChunkID{0});
+}
+
+TEST_F(StorageTableTest, AddColumn) {
+  t.add_column("col_3", "int");
+  EXPECT_EQ(t.column_count(), 3);
+
+  t.append({4, "Something", 5});
+  EXPECT_THROW(t.add_column("col_4", "int"), std::exception);
 }
 
 TEST_F(StorageTableTest, ColumnCount) { EXPECT_EQ(t.column_count(), 2u); }
@@ -53,15 +61,19 @@ TEST_F(StorageTableTest, RowCount) {
 TEST_F(StorageTableTest, GetColumnName) {
   EXPECT_EQ(t.column_name(ColumnID{0}), "col_1");
   EXPECT_EQ(t.column_name(ColumnID{1}), "col_2");
-  // TODO(anyone): Do we want checks here?
-  // EXPECT_THROW(t.column_name(ColumnID{2}), std::exception);
+  EXPECT_THROW(t.column_name(ColumnID{2}), std::exception);
+}
+
+TEST_F(StorageTableTest, ColumnNames) {
+  std::vector<std::string> column_names = t.column_names();
+  std::sort(column_names.begin(), column_names.end());
+  EXPECT_EQ(column_names, std::vector<std::string>({"col_1", "col_2"}));
 }
 
 TEST_F(StorageTableTest, GetColumnType) {
   EXPECT_EQ(t.column_type(ColumnID{0}), "int");
   EXPECT_EQ(t.column_type(ColumnID{1}), "string");
-  // TODO(anyone): Do we want checks here?
-  // EXPECT_THROW(t.column_type(ColumnID{2}), std::exception);
+  EXPECT_THROW(t.column_type(ColumnID{2}), std::exception);
 }
 
 TEST_F(StorageTableTest, GetColumnIdByName) {

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -31,13 +31,16 @@ TEST_F(StorageTableTest, ChunkCount) {
 }
 
 TEST_F(StorageTableTest, GetChunk) {
-  t.get_chunk(ChunkID{0});
-  EXPECT_THROW(t.get_chunk(ChunkID{7}), std::exception);
+  EXPECT_EQ(t.get_chunk(ChunkID{0}).size(), 0u);
+  EXPECT_EQ(std::as_const(t).get_chunk(ChunkID{0}).size(), 0u);
+  EXPECT_THROW(t.get_chunk(ChunkID{1}), std::exception);
+
   t.append({4, "Hello,"});
   t.append({6, "world"});
+  EXPECT_EQ(t.get_chunk(ChunkID{0}).size(), 2u);
+
   t.append({3, "!"});
-  t.get_chunk(ChunkID{1});
-  std::as_const(t).get_chunk(ChunkID{0});
+  EXPECT_EQ(t.get_chunk(ChunkID{1}).size(), 1u);
 }
 
 TEST_F(StorageTableTest, AddColumn) {

--- a/src/test/storage/value_segment_test.cpp
+++ b/src/test/storage/value_segment_test.cpp
@@ -60,11 +60,11 @@ TEST_F(StorageValueSegmentTest, AccessValueAtIndex) {
   EXPECT_THROW(double_value_segment[1], std::exception);
 }
 
-// TEST_F(StorageValueSegmentTest, MemoryUsage) {
-//   int_value_segment.append(1);
-//   EXPECT_EQ(int_value_segment.estimate_memory_usage(), size_t{4});
-//   int_value_segment.append(2);
-//   EXPECT_EQ(int_value_segment.estimate_memory_usage(), size_t{8});
-// }
+TEST_F(StorageValueSegmentTest, MemoryUsage) {
+  int_value_segment.append(1);
+  EXPECT_EQ(int_value_segment.estimate_memory_usage(), size_t{4});
+  int_value_segment.append(2);
+  EXPECT_EQ(int_value_segment.estimate_memory_usage(), size_t{8});
+}
 
 }  // namespace opossum

--- a/src/test/storage/value_segment_test.cpp
+++ b/src/test/storage/value_segment_test.cpp
@@ -9,42 +9,55 @@
 
 namespace opossum {
 
-// class StorageValueSegmentTest : public BaseTest {
-//  protected:
-//   ValueSegment<int> int_value_segment;
-//   ValueSegment<std::string> string_value_segment;
-//   ValueSegment<double> double_value_segment;
-// };
+class StorageValueSegmentTest : public BaseTest {
+ protected:
+  ValueSegment<int> int_value_segment;
+  ValueSegment<std::string> string_value_segment;
+  ValueSegment<double> double_value_segment;
+};
 
-// TEST_F(StorageValueSegmentTest, GetSize) {
-//   EXPECT_EQ(int_value_segment.size(), 0u);
-//   EXPECT_EQ(string_value_segment.size(), 0u);
-//   EXPECT_EQ(double_value_segment.size(), 0u);
-// }
+TEST_F(StorageValueSegmentTest, GetSize) {
+  EXPECT_EQ(int_value_segment.size(), 0u);
+  EXPECT_EQ(string_value_segment.size(), 0u);
+  EXPECT_EQ(double_value_segment.size(), 0u);
+}
 
-// TEST_F(StorageValueSegmentTest, AddValueOfSameType) {
-//   int_value_segment.append(3);
-//   EXPECT_EQ(int_value_segment.size(), 1u);
+TEST_F(StorageValueSegmentTest, AddValueOfSameType) {
+  int_value_segment.append(3);
+  EXPECT_EQ(int_value_segment.size(), 1u);
 
-//   string_value_segment.append("Hello");
-//   EXPECT_EQ(string_value_segment.size(), 1u);
+  string_value_segment.append("Hello");
+  EXPECT_EQ(string_value_segment.size(), 1u);
 
-//   double_value_segment.append(3.14);
-//   EXPECT_EQ(double_value_segment.size(), 1u);
-// }
+  double_value_segment.append(3.14);
+  EXPECT_EQ(double_value_segment.size(), 1u);
+}
 
-// TEST_F(StorageValueSegmentTest, AddValueOfDifferentType) {
-//   int_value_segment.append(3.14);
-//   EXPECT_EQ(int_value_segment.size(), 1u);
-//   EXPECT_THROW(int_value_segment.append("Hi"), std::exception);
+TEST_F(StorageValueSegmentTest, AddValueOfDifferentType) {
+  int_value_segment.append(3.14);
+  EXPECT_EQ(int_value_segment.size(), 1u);
+  EXPECT_THROW(int_value_segment.append("Hi"), std::exception);
 
-//   string_value_segment.append(3);
-//   string_value_segment.append(4.44);
-//   EXPECT_EQ(string_value_segment.size(), 2u);
+  string_value_segment.append(3);
+  string_value_segment.append(4.44);
+  EXPECT_EQ(string_value_segment.size(), 2u);
 
-//   double_value_segment.append(4);
-//   EXPECT_EQ(double_value_segment.size(), 1u);
-//   EXPECT_THROW(double_value_segment.append("Hi"), std::exception);
-// }
+  double_value_segment.append(4);
+  EXPECT_EQ(double_value_segment.size(), 1u);
+  EXPECT_THROW(double_value_segment.append("Hi"), std::exception);
+}
+
+TEST_F(StorageValueSegmentTest, AccessValues) {
+  int_value_segment.append(3);
+  int_value_segment.append(4);
+  EXPECT_EQ(int_value_segment.values(), std::vector<int>({3, 4}));
+}
+
+TEST_F(StorageValueSegmentTest, AccessValueAtIndex) {
+  int_value_segment.append(3);
+  EXPECT_EQ(int_value_segment[0], static_cast<AllTypeVariant>(3));
+  EXPECT_THROW(double_value_segment[-1], std::exception);
+  EXPECT_THROW(double_value_segment[1], std::exception);
+}
 
 }  // namespace opossum


### PR DESCRIPTION
This PR adds implementation for Sprint2 and integrated changes from the PR review from Sprint1.

Changes include:

- Implementation of DictionarySegment, FixedSizedAttributeVector, `Table::compress_chunk()` and `Table::emplace_chunk()`
- Updated implementation of `Table::row_count()`
- Tests for the implemented features
